### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/ha_connector/manifest.json
+++ b/custom_components/ha_connector/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": [],
   "codeowners": ["@fison67"],
   "requirements": [],
-  "config_flow": true
+  "config_flow": true,
+  "version": "1.0.1"
 }


### PR DESCRIPTION
manifest.json add version attribute

HA 최신버전 업데이트에 따라 version 정보가 누락되면 로딩이 안된다고 하네요^^
아마 2021.4.0 버전이나 그 이후가 되지 않을까 싶습니다!